### PR TITLE
Fix usage on Windows.

### DIFF
--- a/src/main/kotlin/com/appunite/placeholdersvalidator/PlaceholdersValidatorTask.kt
+++ b/src/main/kotlin/com/appunite/placeholdersvalidator/PlaceholdersValidatorTask.kt
@@ -17,12 +17,16 @@ open class PlaceholdersValidatorTask : DefaultTask() {
     fun validateStringsPlaceholders() {
         description = "Validates placeholders from translated strings.xml files"
 
+        val isStringXmlInValuesFolder = { path : String ->
+            path.endsWith("/values/strings.xml") || path.endsWith("\\values\\strings.xml")
+        }
+
         val mainStringsFile: File = resourcesDir.find {
-            it.absolutePath.endsWith("/values/strings.xml")
+            isStringXmlInValuesFolder(it.absolutePath)
         }!!
 
         val translatedStrings: List<File> = resourcesDir.filter {
-            it.name == "strings.xml" && !it.absolutePath.endsWith("/values/strings.xml")
+            it.name == "strings.xml" && !isStringXmlInValuesFolder(it.absolutePath)
         }.files.toList()
 
         val mainFilePlaceholders: PlaceholdersForFile = createStringPlaceholdersMap(mainStringsFile)


### PR DESCRIPTION
On Windows path separator differs from *nix OSs, so provided linux path '/valies/strings.xml' is not correct on Windows, and gradle build fails with exception.
This patch fixes this issue by verifying provided path string with both *nix-like and windows-like paths.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>